### PR TITLE
Minor updates

### DIFF
--- a/app/(auth)/home/index.tsx
+++ b/app/(auth)/home/index.tsx
@@ -31,10 +31,9 @@ export default function Home() {
                 }}
               >
                 {
-                  showList ?
-                    <Entypo name="list" size={24} color="black" />
-                    :
-                    <MaterialCommunityIcons name="cards-variant" size={24} color="black" />
+                  showList
+                    ? <MaterialCommunityIcons name="cards-variant" size={24} color="black" />
+                    : <Entypo name="list" size={24} color="black" />
                 }
               </View>
             </Pressable>

--- a/contexts/session.tsx
+++ b/contexts/session.tsx
@@ -70,7 +70,7 @@ export function SessionProvider({ children }: PropsWithChildren) {
         router.replace('/signin')
       }
     }
-  }, [session]);
+  }, [session, sessionLoading]);
 
   useEffect(() => {
     const handleDeepLink = async (event: any) => {


### PR DESCRIPTION
Introduced some minor updates including:

1. Switch places the list and swiping card icons:

** New behavior **: If the home screen is in `List` mode, the `card` mode displays and vice versa.

2. Missing getting hook to session data loading state

In some cases, the session context missed from getting hooked to the loading state, results in unexpected behavior and get stuck at the loading screen.