### PR TITLE
Add build instruction

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,19 @@
+
+
+To build for android, before running `npx expo run:android`, run:
+
+```bash
+mkdir -p android && echo "sdk.dir=$ANDROID_SDK_ROOT" > android/local.properties
+```
+
+or set the `ANDROID_SDK_ROOT` environment variable.
+
+```bash
+export ANDROID_SDK_ROOT=/path/to/android/sdk
+```
+
+This is required because the Android SDK is not installed in the default location on the build server.
+The `path/to/android/sdk` usually locates in:
+
+- Windows: `C:\Users\YOUR_USERNAME\AppData\Local\Android\Sdk`
+- macOS: `/Users/YOUR_USERNAME/Library/Android/sdk`


### PR DESCRIPTION
## Add build instruction for android

Since the Android SDK is located in `local.properties` which is located in `./android`, an ignored dir from git, any changes made to that DIR is NOT reflected on the git side and any erasing actions will result in permanent loss, including the mentioned `local.properties`.

So this markdown file instructs how to create it from scratch in such events.